### PR TITLE
Removal of extra llstr variable from 3_linked_list.py file

### DIFF
--- a/data_structures/3_LinkedList/3_linked_list.py
+++ b/data_structures/3_LinkedList/3_linked_list.py
@@ -13,7 +13,7 @@ class LinkedList:
             return
         itr = self.head
         while itr:
-            print(itr.data, end="-->") if itr.next is not None else print(itr.data)
+            print(itr.data, end="-->") if itr.next else print(itr.data)
             itr = itr.next
 
     def get_length(self):

--- a/data_structures/3_LinkedList/3_linked_list.py
+++ b/data_structures/3_LinkedList/3_linked_list.py
@@ -12,11 +12,9 @@ class LinkedList:
             print("Linked list is empty")
             return
         itr = self.head
-        llstr = ''
         while itr:
-            llstr += str(itr.data)+' --> ' if itr.next else str(itr.data)
+            print(itr.data, end="-->") if itr.next is not None else print(itr.data)
             itr = itr.next
-        print(llstr)
 
     def get_length(self):
         count = 0


### PR DESCRIPTION
print statement provides an option to specify delimiter, so I have added an alternative way to print linked list without use of extra variable.

Regards,
V